### PR TITLE
Distributed jobs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+Style/RescueStandardError:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,5 @@
+Metrics/AbcSize:
+  Max: 30  # 15
+
 Style/RescueStandardError:
   Enabled: false

--- a/README.rdoc
+++ b/README.rdoc
@@ -123,6 +123,50 @@ is raised if the job is killed.
 
   at(steps_completed, total_steps, "${steps_completed} of #{total_steps} steps completed!")
 
+=== Distributed job
+
+With Status you can create a destributed parent/child job, that will run some part of the processing,
+in multiple, potentially parallel child jobs and then do somthing when all child jobs will finish.
+To do this you first need to define <tt>perform_child</tt> method. This method will be called in child jobs
+instead of <tt>perform</tt>. Then, in the parent's <tt>perform</tt>, you need initiate parent using <tt>init_parent(total)</tt>,
+and finally queue children using <tt>enqueue_child(options)</tt>.
+The progress is tracked automatically using regular "num" and "total" fields. The "total" will be set to
+the "total" from <tt>init_parent</tt> and <tt>num</tt> will be incresed by 1 for each finished job, so DO NOT change them manually.
+When all child jobs will finish, the last one will call <tt>onsuccess</tt> in its own context.
+
+Example:
+
+    class VeryHeavyJob
+      include Resque::Plugins::Status
+
+      def perform
+        init_parent(options['items'].size)
+        options['items'].each do |item|
+          enqueue_child('item' => item)
+        end
+      end
+
+      def perform_child
+        process_item(options['item'])
+      end
+
+      def on_success
+        send_email "yey! all items finished"
+      end
+    end
+
+If you need to get status/options of the parent, you can use <tt>parent_uuid</tt> method and get the status, like this:
+
+    Resque::Plugins::Status::Hash.get(parent_uuid)
+
+
+The statuses of child jobs will be deleted, unless it failed. In case of failure on child level, the parent will stay "working"
+forever, and child status will be preserved, so that you can investigate the issue and retry the child. Once it succeeds,
+it will mark the parent as completed.
+The child jobs will not call callbacks for each job, only once when all are finished.
+When parent job is killed using <tt>Resque::Plugins::Status::Hash.kill</tt> it will skip all child jobs that didn't start yet,
+and once all child jobs are either finished or skipped, it will set the parent job's status to "killed" and call "on_killed"
+
 === Expiration
 
 Since Redis is RAM based, we probably don't want to keep these statuses around forever

--- a/README.rdoc
+++ b/README.rdoc
@@ -167,6 +167,26 @@ The child jobs will not call callbacks for each job, only once when all are fini
 When parent job is killed using <tt>Resque::Plugins::Status::Hash.kill</tt> it will skip all child jobs that didn't start yet,
 and once all child jobs are either finished or skipped, it will set the parent job's status to "killed" and call "on_killed"
 
+=== Retry failed job
+
+There are 2 optional settings that allow to retry failed job.
+
+    self.retry_failed = 2
+
+will retry only regular (not child) failed job 2 times (totally 3 runs), and
+
+    self.retry_failed_child = 3
+
+will retry child job 3 times (total 4 runs).
+
+Not setting it or setting it to zero disables the retry. The retry will work both in case of exception that failed the job
+or if the failed status was set manually.
+
+Note: The retry limit works by incrementing 'retry_num' status field and if changed manually will break.
+
+Note2: <tt>on_failed</tt> callback, if defined, will be called each time.
+
+
 === Expiration
 
 Since Redis is RAM based, we probably don't want to keep these statuses around forever

--- a/lib/resque/plugins/status.rb
+++ b/lib/resque/plugins/status.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Resque
   module Plugins
 
@@ -49,7 +51,7 @@ module Resque
       class Killed < RuntimeError; end
       class NotANumber < RuntimeError; end
 
-      attr_reader :uuid, :options
+      attr_reader :uuid, :options, :parent_uuid
 
       def self.included(base)
         base.extend(ClassMethods)
@@ -134,7 +136,7 @@ module Resque
         def perform(uuid=nil, options = {})
           uuid ||= Resque::Plugins::Status::Hash.generate_uuid
           instance = new(uuid, options)
-          instance.safe_perform!
+          instance.parent_uuid ? instance.child_safe_perform! : instance.safe_perform!
           instance
         end
 
@@ -150,6 +152,7 @@ module Resque
       def initialize(uuid, options = {})
         @uuid    = uuid
         @options = options
+        @parent_uuid = options['_parent_uuid']
       end
 
       # Run by the Resque::Worker when processing this job. It wraps the <tt>perform</tt>
@@ -159,10 +162,13 @@ module Resque
       def safe_perform!
         set_status({'status' => STATUS_WORKING, 'started_at' => Time.now.to_i })
         perform
-        if status && status.failed?
-          on_failure(status.message) if respond_to?(:on_failure)
+        job_status = status
+        if job_status&.failed?
+          on_failure(job_status.message) if respond_to?(:on_failure)
           return
-        elsif status && !status.completed?
+        elsif @is_parent_job
+          return
+        elsif job_status && !job_status.completed?
           completed
         end
         on_success if respond_to?(:on_success)
@@ -176,6 +182,16 @@ module Resque
         else
           raise e
         end
+      end
+
+      def child_safe_perform!
+        set_status('status' => STATUS_WORKING, 'started_at' => Time.now.to_i)
+        perform_child unless parent_should_kill?
+        completed if status&.working?
+        child_complete unless status&.failed?
+      rescue => e
+        failed("The task failed because of an error: #{e}")
+        raise e
       end
 
       # Set the jobs status. Can take an array of strings or hashes that are merged
@@ -197,6 +213,10 @@ module Resque
       # on the next iteration
       def should_kill?
         Resque::Plugins::Status::Hash.should_kill?(uuid)
+      end
+
+      def parent_should_kill?
+        Resque::Plugins::Status::Hash.should_kill?(parent_uuid)
       end
 
       # set the status of the job for the current itteration. <tt>num</tt> and
@@ -243,7 +263,40 @@ module Resque
         raise Killed
       end
 
+      # Initiates parent once total number of child jobs is known
+      # This step is essential to prevent race condition of all currently queued children finish,
+      # while parent still plans to enqueue more.
+      # When child job completes, it increments the `num` of the parent job by 1.
+      # When `num` gets == `total` the parent job marked as complete and `on_success` is called on the last child job
+      # If parent is killed, all children are prevented from running
+      # Child job statuses are deleted when complete or killed to avoid garbage in redis. It's preserved on error.
+      def init_parent(total)
+        at(0, total, "Queuing #{total} subjobs")
+        @is_parent_job = true
+      end
+
+      # Enqueues the same class with `options` as a child of the current job
+      def enqueue_child(options)
+        raise 'Parent not initiated' unless @is_parent_job
+
+        self.class.create(options.merge('_parent_uuid' => uuid))
+      end
+
       private
+
+      def child_complete
+        parent = Resque::Plugins::Status::Hash.incr(parent_uuid, 'num', 1)
+        Resque::Plugins::Status::Hash.remove(uuid)
+        return if parent.num != parent.total
+
+        if parent_should_kill?
+          Resque::Plugins::Status::Hash.set(parent_uuid, parent, 'status' => STATUS_KILLED)
+          on_killed if respond_to?(:on_killed)
+        else
+          Resque::Plugins::Status::Hash.set(parent_uuid, parent, 'status' => STATUS_COMPLETED, 'message' => '')
+          on_success if respond_to?(:on_success)
+        end
+      end
 
       def set_status(*args)
         self.status = [status, {'name'  => self.name, 'time' => Time.now.to_i}, args].flatten

--- a/lib/resque/plugins/status.rb
+++ b/lib/resque/plugins/status.rb
@@ -58,6 +58,7 @@ module Resque
       end
 
       module ClassMethods
+        attr_accessor :retry_failed, :retry_failed_child
 
         # The default queue is :statused, this can be ovveridden in the specific job
         # class to put the jobs on a specific worker queue
@@ -165,6 +166,7 @@ module Resque
         job_status = status
         if job_status&.failed?
           on_failure(job_status.message) if respond_to?(:on_failure)
+          retry_if_can
           return
         elsif @is_parent_job
           return
@@ -177,20 +179,23 @@ module Resque
         on_killed if respond_to?(:on_killed)
       rescue => e
         failed("The task failed because of an error: #{e}")
-        if respond_to?(:on_failure)
-          on_failure(e)
-        else
-          raise e
-        end
+        on_failure(e) if respond_to?(:on_failure)
+        retry_if_can
+        raise e unless respond_to?(:on_failure)
       end
 
       def child_safe_perform!
         set_status('status' => STATUS_WORKING, 'started_at' => Time.now.to_i)
         perform_child unless parent_should_kill?
         completed if status&.working?
-        child_complete unless status&.failed?
+        if status&.failed?
+          retry_if_can
+        else
+          child_complete
+        end
       rescue => e
         failed("The task failed because of an error: #{e}")
+        retry_if_can
         raise e
       end
 
@@ -283,6 +288,14 @@ module Resque
       end
 
       private
+
+      def retry_if_can
+        retry_limit = parent_uuid ? self.class.retry_failed_child : self.class.retry_failed
+        return if status['retry_num'].to_i >= retry_limit.to_i
+
+        set_status('retry_num' => status['retry_num'].to_i + 1, 'status' => STATUS_QUEUED)
+        Resque.enqueue(self.class, uuid, options)
+      end
 
       def child_complete
         parent = Resque::Plugins::Status::Hash.incr(parent_uuid, 'num', 1)

--- a/lib/resque/plugins/status/hash.rb
+++ b/lib/resque/plugins/status/hash.rb
@@ -45,6 +45,15 @@ module Resque
           val
         end
 
+        # Atomically increment a value in the hash
+        def self.incr(uuid, key, by = 1)
+          sleep(0.01) until redis.set("lock:update:#{uuid}", 1, nx: true, ex: 10)
+          hash = get(uuid)
+          set(uuid, hash, key => hash[key] + by)
+        ensure
+          redis.del("lock:update:#{uuid}")
+        end
+
         # clear statuses from redis passing an optional range. See `statuses` for info
         # about ranges
         def self.clear(range_start = nil, range_end = nil)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,7 @@ require 'resque-status'
 require 'minitest/autorun'
 require 'mocha/setup'
 require 'timecop'
+require 'byebug'
 
 #
 # make sure we can run redis
@@ -49,6 +50,27 @@ class WorkingJob
     end
   end
 
+end
+
+class WorkingParentJob
+  include Resque::Plugins::Status
+
+  def perform
+    init_parent(3)
+    # This is a workaround to test killing job while it enqueues children with inline resque.
+    # The real use case would be that the `kill` would happen somewhere in the middle of subjob runs,
+    # long after the main job finished.
+    Resque::Plugins::Status::Hash.kill(@uuid) if options['self_kill']
+    3.times { |i| enqueue_child('job_num' => i) }
+  end
+
+  def perform_child
+    Resque.redis.sadd('child_jobs_done', options['job_num'])
+  end
+
+  def on_success
+    Resque.redis.sadd('child_on_success', options['job_num'] || 'parent')
+  end
 end
 
 class ErrorJob

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -60,16 +60,21 @@ class WorkingParentJob
     # This is a workaround to test killing job while it enqueues children with inline resque.
     # The real use case would be that the `kill` would happen somewhere in the middle of subjob runs,
     # long after the main job finished.
-    Resque::Plugins::Status::Hash.kill(@uuid) if options['self_kill']
-    3.times { |i| enqueue_child('job_num' => i) }
+    Resque::Plugins::Status::Hash.kill(uuid) if options['self_kill']
+    Resque.redis.incr('parent_start_count')
+    3.times { |i| enqueue_child(options.merge('job_num' => i)) }
+    raise options['error'] if options['error']
   end
 
   def perform_child
-    Resque.redis.sadd('child_jobs_done', options['job_num'])
+    Resque.redis.rpush('child_jobs_done', options['job_num'])
+    # here `failed` and not raise in order for it to work with resque inline
+    # otherwise it throws exception during parent's execution
+    failed options['error'] if options['error']
   end
 
   def on_success
-    Resque.redis.sadd('child_on_success', options['job_num'] || 'parent')
+    Resque.redis.rpush('child_on_success', options['job_num'] || 'parent')
   end
 end
 

--- a/test/test_resque_plugins_status.rb
+++ b/test/test_resque_plugins_status.rb
@@ -366,12 +366,12 @@ class TestResquePluginsStatus < Minitest::Test
     describe 'with WorkingParentJob' do
       before do
         Resque.stubs(:inline?).returns(true)
-        @uuid = WorkingParentJob.create('num' => 100)
+        @uuid = WorkingParentJob.create
       end
 
       it 'should have ran all the children' do
-        assert_equal(%w[0 1 2], Resque.redis.smembers('child_jobs_done').sort)
-        onsuccess_jobs = Resque.redis.smembers('child_on_success')
+        assert_equal(%w[0 1 2], Resque.redis.lrange('child_jobs_done', 0, -1))
+        onsuccess_jobs = Resque.redis.lrange('child_on_success', 0, -1)
         assert_equal 1, onsuccess_jobs.size
         assert_includes(%w[0 1 2], onsuccess_jobs[0])
         status = Resque::Plugins::Status::Hash.get(@uuid)
@@ -380,15 +380,68 @@ class TestResquePluginsStatus < Minitest::Test
       end
     end
 
+    describe 'with failing WorkingParentJob' do
+      before do
+        Resque.stubs(:inline?).returns(true)
+        @options = { 'error' => 'test error' }
+        @uuid = Resque::Plugins::Status::Hash.generate_uuid
+      end
+
+      after do
+        WorkingParentJob.retry_failed = nil
+        WorkingParentJob.retry_failed_child = nil
+      end
+
+      it 'can retry parent' do
+        WorkingParentJob.retry_failed = 2
+        assert_raises RuntimeError do
+          WorkingParentJob.perform(@uuid, @options)
+        end
+
+        status = Resque::Plugins::Status::Hash.get(@uuid)
+        assert status.failed?
+        assert_equal 2, status['retry_num']
+        assert_equal '3', Resque.redis.get('parent_start_count')
+        assert_equal(%w[0 1 2] * 3, Resque.redis.lrange('child_jobs_done', 0, -1))
+      end
+
+      it 'can retry child' do
+        WorkingParentJob.retry_failed_child = 1
+        assert_raises RuntimeError do
+          WorkingParentJob.perform(@uuid, @options)
+        end
+
+        status = Resque::Plugins::Status::Hash.get(@uuid)
+        assert status.failed?
+        assert_nil status['retry_num']
+        assert_equal '1', Resque.redis.get('parent_start_count')
+        assert_equal(%w[0 0 1 1 2 2], Resque.redis.lrange('child_jobs_done', 0, -1))
+      end
+
+      it 'can retry parent and child' do
+        WorkingParentJob.retry_failed = 2
+        WorkingParentJob.retry_failed_child = 1
+        assert_raises RuntimeError do
+          WorkingParentJob.perform(@uuid, @options)
+        end
+
+        status = Resque::Plugins::Status::Hash.get(@uuid)
+        assert status.failed?
+        assert_equal 2, status['retry_num']
+        assert_equal '3', Resque.redis.get('parent_start_count')
+        assert_equal(%w[0 0 1 1 2 2] * 3, Resque.redis.lrange('child_jobs_done', 0, -1))
+      end
+    end
+
     describe 'with self killing WorkingParentJob' do
       before do
         Resque.stubs(:inline?).returns(true)
-        @uuid = WorkingParentJob.create('num' => 100, 'self_kill' => true)
+        @uuid = WorkingParentJob.create('self_kill' => true)
       end
 
-      it 'should have ran all the children' do
-        assert_equal([], Resque.redis.smembers('child_jobs_done'))
-        assert_equal([], Resque.redis.smembers('child_on_success'))
+      it 'should skip all the children' do
+        assert_equal([], Resque.redis.lrange('child_jobs_done', 0, -1))
+        assert_equal([], Resque.redis.lrange('child_on_success', 0, -1))
         status = Resque::Plugins::Status::Hash.get(@uuid)
         assert_equal 3, status.num
         assert_equal 'killed', status.status

--- a/test/test_resque_plugins_status.rb
+++ b/test/test_resque_plugins_status.rb
@@ -363,6 +363,36 @@ class TestResquePluginsStatus < Minitest::Test
 
     end
 
-  end
+    describe 'with WorkingParentJob' do
+      before do
+        Resque.stubs(:inline?).returns(true)
+        @uuid = WorkingParentJob.create('num' => 100)
+      end
 
+      it 'should have ran all the children' do
+        assert_equal(%w[0 1 2], Resque.redis.smembers('child_jobs_done').sort)
+        onsuccess_jobs = Resque.redis.smembers('child_on_success')
+        assert_equal 1, onsuccess_jobs.size
+        assert_includes(%w[0 1 2], onsuccess_jobs[0])
+        status = Resque::Plugins::Status::Hash.get(@uuid)
+        assert_equal 3, status.num
+        assert_equal 'completed', status.status
+      end
+    end
+
+    describe 'with self killing WorkingParentJob' do
+      before do
+        Resque.stubs(:inline?).returns(true)
+        @uuid = WorkingParentJob.create('num' => 100, 'self_kill' => true)
+      end
+
+      it 'should have ran all the children' do
+        assert_equal([], Resque.redis.smembers('child_jobs_done'))
+        assert_equal([], Resque.redis.smembers('child_on_success'))
+        status = Resque::Plugins::Status::Hash.get(@uuid)
+        assert_equal 3, status.num
+        assert_equal 'killed', status.status
+      end
+    end
+  end
 end

--- a/test/test_resque_plugins_status_hash.rb
+++ b/test/test_resque_plugins_status_hash.rb
@@ -162,6 +162,24 @@ class TestResquePluginsStatusHash < Minitest::Test
       end
     end
 
+    describe '.incr' do
+      before do
+        @uuid = Resque::Plugins::Status::Hash.generate_uuid
+        Resque::Plugins::Status::Hash.set(@uuid, 'num' => 10)
+      end
+
+      it 'increments value' do
+        Resque::Plugins::Status::Hash.incr(@uuid, 'num')
+        assert_equal 11, Resque::Plugins::Status::Hash.get(@uuid).num
+        Resque::Plugins::Status::Hash.incr(@uuid, 'num', 4)
+        assert_equal 15, Resque::Plugins::Status::Hash.get(@uuid).num
+        Resque::Plugins::Status::Hash.incr(@uuid, 'num', -5)
+        assert_equal 10, Resque::Plugins::Status::Hash.get(@uuid).num
+        10.times.map { Thread.new { Resque::Plugins::Status::Hash.incr(@uuid, 'num') } }.each(&:join)
+        assert_equal 20, Resque::Plugins::Status::Hash.get(@uuid).num
+      end
+    end
+
     describe ".status_ids" do
 
       before do


### PR DESCRIPTION
A couple of our internal jobs already use a similar mechanism for distributed jobs, each with its own implementation but usually with different jobs. Here using changes directly in Status code, I could get it to define a distributed job in the same class using `perform` - parent processing, `perform_child` - the distributed part, and `on_success` - finishing part.